### PR TITLE
updated search() to return pair object

### DIFF
--- a/simplestat.cpp
+++ b/simplestat.cpp
@@ -243,8 +243,9 @@ int SimpleStat<E>::length_unique()
 
 
 template <typename E>
-void SimpleStat<E>::search(double val)
+std::pair<E, E> SimpleStat<E>::search(double val)
 {
+    std::pair<E, E> num_reps;
     int rep_first = -1;
     int rep_total = 0;
     int count = 0;
@@ -263,8 +264,11 @@ void SimpleStat<E>::search(double val)
         std::cout << val << " does not exist in this data set." << std::endl;
     }
     else {
-        std::cout << val << " first appears in the data set at " << rep_first << " with " << rep_total << " total repetitions." << std::endl;
+        num_reps.first = rep_first;
+        num_reps.second = rep_total;
+        std::cout << num_reps.first << ", " << num_reps.second << std::endl;
     }
+    return num_reps;
 }
 
 

--- a/simplestat.h
+++ b/simplestat.h
@@ -30,7 +30,7 @@ class SimpleStat {
     int length_total();
     int length_unique();
     std::set<E> unique_set();
-    void search(double val);
+    std::pair<E, E> search(double val);
     E operator[](int index);
 
     // Modifiers


### PR DESCRIPTION
we should change the README file to list the search() function as one that returns a pair instead of a set